### PR TITLE
Add question mark between url and parameters for historical and intraday calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "recordings:clean": "rm -rf ./__recordings__",
     "version": "run-s doc:html doc:publish",
     "prepare-release": "run-s doc:html standard-version doc:publish",
+    "prepack": "run-s clean && run-p build:*",
     "release": "np"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "recordings:clean": "rm -rf ./__recordings__",
     "version": "run-s doc:html doc:publish",
     "prepare-release": "run-s doc:html standard-version doc:publish",
-    "postinstall": "run-s clean && run-p build:*",
     "release": "np"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "recordings:clean": "rm -rf ./__recordings__",
     "version": "run-s doc:html doc:publish",
     "prepare-release": "run-s doc:html standard-version doc:publish",
-    "prepack": "run-s clean && run-p build:*",
+    "postinstall": "run-s clean && run-p build:*",
     "release": "np"
   },
   "dependencies": {

--- a/src/endpoints/stock-prices/HistoricalPrice.test.ts
+++ b/src/endpoints/stock-prices/HistoricalPrice.test.ts
@@ -5,4 +5,16 @@ describe('#historicalPrices', () => {
     const result = await historicalPrices('AAPL');
     expect(result).not.toEqual(null);
   });
+
+  test('call returns data correctly with range', async () => {
+    const result = await historicalPrices('AAPL', '1d');
+    expect(result).not.toEqual(null);
+  })
+
+  test('structure is correct with range and parameters', async () => {
+    const result = await historicalPrices('AAPL', '1d', undefined, {
+      chartInterval: 15
+    });
+    expect(result).not.toEqual(null);
+  })
 });

--- a/src/endpoints/stock-prices/HistoricalPrice.ts
+++ b/src/endpoints/stock-prices/HistoricalPrice.ts
@@ -15,7 +15,7 @@ export const historicalPrices = (
   params?: Partial<HistoricalPriceParams>,
 ): Promise<ReadonlyArray<Partial<HistoricalPrice>>> => {
   const path = `stock/${symbol}/chart/${[range, date].filter(x => isString(x)).join('/')}`;
-  return ApiRequest(path + paramsToQuery(params));
+  return ApiRequest(path + paramsToQuery(params, true));
 };
 
 export interface HistoricalPrice {

--- a/src/endpoints/stock-prices/IntradayPrice.test.ts
+++ b/src/endpoints/stock-prices/IntradayPrice.test.ts
@@ -5,4 +5,11 @@ describe('#intradayPrices', () => {
     const result = await intradayPrices('AAPL');
     expect(result).not.toEqual(null);
   });
+
+  test('call with parameters', async () => {
+    const result = await intradayPrices('AAPL', {
+      chartIEXWhenNull: true
+    });
+    expect(result).not.toEqual(null);
+  })
 });

--- a/src/endpoints/stock-prices/IntradayPrice.ts
+++ b/src/endpoints/stock-prices/IntradayPrice.ts
@@ -12,7 +12,7 @@ export const intradayPrices = (
   symbol: string,
   params?: Partial<IntradayPriceParams>,
 ): Promise<readonly IntradayPrice[]> => {
-  return ApiRequest(`stock/${symbol}/intraday-prices` + paramsToQuery(params));
+  return ApiRequest(`stock/${symbol}/intraday-prices` + paramsToQuery(params, true));
 };
 
 export interface IntradayPrice {

--- a/src/utils/paramsToQuery.ts
+++ b/src/utils/paramsToQuery.ts
@@ -1,7 +1,13 @@
-export const paramsToQuery = (params: any) => {
+/**
+ * Takes an object and turns them into query parameters for a URL
+ * @param params Object to convert to query parameters
+ * @param addQuestionMark Optional: indicates whether to begin the query parameters with a question mark
+ * @returns Query parameters in string format, ready to be used in a URL
+ */
+export const paramsToQuery = (params: any, addQuestionMark?: boolean): string => {
   return !params || params === {}
     ? ''
-    : `${Object.keys(params)
+    : `${addQuestionMark ? '?' : ''}${Object.keys(params)
         .map(x => [x, params[x]].join('='))
         .join('&')}`;
 };


### PR DESCRIPTION


- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix, found both the historical call and the intraday call did not use the `?` between the URL and the query parameters.

- **What is the current behavior?** (You can also link to an open issue here)
Current functionality produced the following URL:
`https://sandbox.iexapis.com/v1/stock/AAPL/chart/1dchartInterval=15`

- **What is the new behavior (if this is a feature change)?**
New changes produces the following URL:
`https://sandbox.iexapis.com/v1/stock/AAPL/chart/1d?chartInterval=15`

- **Other information**:
Also added tests for both endpoints making sure proper query parameters can be passed in
